### PR TITLE
Add GitProvider to retrieve conf file from Git Server.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+os:
+    - linux
+
 jdk:
     - oraclejdk11
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ remote-configuration {
   }
 }
 ```
+You can use `io.playrconf.GitProvier` with three auth modes:
+* None (For public repositories);
+* User (For private repositories over login/password);
+* SSH-RSA (For private repositories over SSH-RSA read only file).
+
+If you use `ssh-rsa` mode, then you must provide the file path on `ssh-rsa.privateKey` config. If your private key has 
+a password, then you must provide `ssh-rsa.password`.
 
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -141,5 +141,15 @@
             <version>2.16.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>5.9.0.202009080501-r</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
+            <version>5.9.0.202009080501-r</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/io/playrconf/provider/GitProvider.java
+++ b/src/main/java/io/playrconf/provider/GitProvider.java
@@ -48,11 +48,12 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.eclipse.jgit.util.FS;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Properties;
@@ -221,11 +222,12 @@ public class GitProvider extends AbstractProvider {
      * @param branch Branch name.
      * @return Repository.
      */
-    private Repository cloneRepository(final Config config, final String repositoryURI, final String mode, final String branch) throws GitAPIException {
-        final File repoDir = new File("play-rconf-git", String.format("%s-%s-%d", repositoryURI, branch, System.currentTimeMillis()));
+    private Repository cloneRepository(final Config config, final String repositoryURI, final String mode, final String branch) throws GitAPIException, IOException {
+        String dirPath = String.format("play-rconf-git-%s", String.format("%s-%s-%d", repositoryURI, branch, System.currentTimeMillis()));
+        Path repoDirPath = Files.createTempDirectory(dirPath);
         final CloneCommand cloneCommand = Git.cloneRepository()
             .setURI(repositoryURI)
-            .setDirectory(repoDir);
+            .setDirectory(repoDirPath.toFile());
 
         switch (mode) {
             case "ssh-rsa":

--- a/src/main/java/io/playrconf/provider/GitProvider.java
+++ b/src/main/java/io/playrconf/provider/GitProvider.java
@@ -1,0 +1,282 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 The Play Remote Configuration Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.playrconf.provider;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
+import io.playrconf.sdk.AbstractProvider;
+import io.playrconf.sdk.FileCfgObject;
+import io.playrconf.sdk.KeyValueCfgObject;
+import io.playrconf.sdk.exception.RemoteConfException;
+import org.eclipse.jgit.api.CloneCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.JGitInternalException;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.transport.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.SshSessionFactory;
+import org.eclipse.jgit.transport.SshTransport;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.util.FS;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.function.Consumer;
+
+/**
+ * Retrieves configuration hosted behind a Git repository.
+ * You can use three authentication modes:
+ *      1. None     (Used for public repositories);
+ *      2. User     (Used for private repositories over HTTPS);
+ *      3. SSH-RSA  (Used for private repositories over SSH with a RSA Private Key).
+ *
+ * @author Felipe Bonezi
+ * @since 20.10.29
+ */
+public class GitProvider extends AbstractProvider {
+
+    /**
+     * Contains the provider version.
+     */
+    private static String providerVersion;
+
+    @Override
+    public String getName() {
+        return "Git";
+    }
+
+    @Override
+    public String getVersion() {
+        if (GitProvider.providerVersion == null) {
+            synchronized (GitProvider.class) {
+                final Properties properties = new Properties();
+                final InputStream is = GitProvider.class.getClassLoader()
+                    .getResourceAsStream("playrconf-git.properties");
+                try {
+                    properties.load(is);
+                    GitProvider.providerVersion = properties.getProperty("playrconf.git.version", "unknown");
+                    properties.clear();
+                } catch (final IOException ignore) {
+                } finally {
+                    if (is != null) {
+                        try {
+                            is.close();
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                }
+            }
+        }
+        return GitProvider.providerVersion;
+    }
+
+    @Override
+    public String getConfigurationObjectName() {
+        return "git";
+    }
+
+    @Override
+    public void loadData(Config config,
+                         Consumer<KeyValueCfgObject> kvObjConsumer,
+                         Consumer<FileCfgObject> fileObjConsumer) throws ConfigException, RemoteConfException {
+        this.checkRequiredConfigFields(config);
+
+        try {
+            String mode = config.getString("mode").trim();
+            String repositoryURI = config.getString("uri").trim();
+            String branch = config.getString("branch").trim();
+            String filepath = config.getString("filepath").trim();
+
+            Repository repository = this.cloneRepository(config, repositoryURI, mode, branch);
+            ObjectId head = repository.resolve(Constants.HEAD);
+            RevCommit lastCommit = repository.parseCommit(head);
+
+            String conf = readFile(repository, lastCommit, filepath);
+            final ConfigParseOptions options = ConfigParseOptions
+                .defaults()
+                .setOriginDescription("play-rconf")
+                .setAllowMissing(false);
+
+            final Config remoteConfig = ConfigFactory.parseString(conf, options);
+            remoteConfig.entrySet().forEach(entry -> {
+                final String value = entry.getValue().render();
+                if (isFile(value)) {
+                    fileObjConsumer.accept(
+                        new FileCfgObject(entry.getKey(), value)
+                    );
+                } else {
+                    kvObjConsumer.accept(
+                        new KeyValueCfgObject(entry.getKey(), value)
+                    );
+                }
+            });
+        } catch (final ConfigException ex2) {
+            if (ex2.getCause() != null) {
+                throw new ConfigException.BadPath(
+                    config.getString("uri"),
+                    ex2.getCause().getClass().getName(),
+                    ex2.getCause()
+                );
+            } else {
+                throw new ConfigException.ValidationFailed(
+                    Collections.singletonList(
+                        new ConfigException.ValidationProblem(
+                            config.getString("uri"),
+                            ex2.origin(),
+                            ex2.getMessage()
+                        )
+                    )
+                );
+            }
+        } catch (MalformedURLException | JGitInternalException | GitAPIException e) {
+            throw new ConfigException.BadPath("uri", e.getMessage());
+        } catch (IOException e) {
+            throw new RemoteConfException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Check if all required fields are set in the project config file.
+     * @param config Config file.
+     */
+    private void checkRequiredConfigFields(Config config) throws ConfigException {
+        if (!config.hasPath("mode") || config.getString("mode").isEmpty())
+            throw new ConfigException.Missing("mode");
+
+        if (!config.hasPath("uri") || config.getString("uri").isEmpty())
+            throw new ConfigException.Missing("uri");
+
+        if (!config.hasPath("branch") || config.getString("branch").isEmpty())
+            throw new ConfigException.Missing("branch");
+
+        if (!config.hasPath("filepath") || config.getString("filepath").isEmpty())
+            throw new ConfigException.Missing("filepath");
+
+        String mode = config.getString("mode").trim();
+        String repositoryURI = config.getString("uri").trim();
+
+        if (Objects.equals(mode, "user")) {
+            if (!repositoryURI.startsWith("http")) {
+                throw new ConfigException.BadValue("mode", String.format("Invalid repository URI for %s mode.", mode));
+            }
+
+            if (!config.hasPath("user.login") || config.getString("user.login").isEmpty()) {
+                throw new ConfigException.Missing("user.login");
+            } else if (!config.hasPath("user.password")) {
+                throw new ConfigException.Missing("user.password");
+            }
+        } else if (Objects.equals(mode, "ssh-rsa")) {
+            if (!repositoryURI.startsWith("git@")) {
+                throw new ConfigException.BadValue("mode", String.format("Invalid repository URI for %s mode.", mode));
+            }
+
+            if (!config.hasPath("ssh-rsa.private-key") || config.getString("ssh-rsa.private-key").isEmpty()) {
+                throw new ConfigException.Missing("ssh-rsa.private-key");
+            }
+        }
+    }
+
+    /**
+     * Clones the branch of Git repository.
+     *
+     * @param config Config file.
+     * @param repositoryURI Repository URI using HTTPS or SSH.
+     * @param mode Auth mode.
+     * @param branch Branch name.
+     * @return Repository.
+     */
+    private Repository cloneRepository(Config config, String repositoryURI, String mode, String branch) throws GitAPIException {
+        File repoDir = new File("play-rconf-git", String.format("%s-%s-%d", repositoryURI, branch, System.currentTimeMillis()));
+        CloneCommand cloneCommand = Git.cloneRepository()
+            .setURI(repositoryURI)
+            .setDirectory(repoDir);
+
+        switch (mode) {
+            case "ssh-rsa":
+                SshSessionFactory sshSessionFactory = new JschConfigSessionFactory() {
+
+                    @Override
+                    protected JSch createDefaultJSch(FS fs) throws JSchException {
+                        // SSH configuration (Optional password).
+                        String privateKey = config.getString("ssh-rsa.private-key");
+                        String password = config.hasPath("ssh-rsa.password") ?
+                            config.getString("ssh-rsa.password") : null;
+                        JSch jSch = super.createDefaultJSch(fs);
+                        jSch.addIdentity(privateKey, password);
+                        return jSch;
+                    }
+
+                };
+                cloneCommand.setTransportConfigCallback(transport -> {
+                    SshTransport sshTransport = (SshTransport) transport;
+                    sshTransport.setSshSessionFactory(sshSessionFactory);
+                });
+                break;
+
+            case "user":
+                String username = config.getString("user.login");
+                String password = config.getString("user.password");
+                cloneCommand.setCredentialsProvider(new UsernamePasswordCredentialsProvider(username, password));
+
+            default:
+                // Public repository over HTTPS.
+                break;
+        }
+
+        return cloneCommand.call().getRepository();
+    }
+
+    /**
+     * Read config file from repository.
+     * @param repository Repository ref.
+     * @param commit Last commit ref from the current branch.
+     * @param filepath Path to retrieve the config content.
+     * @return Config content as String.
+     */
+    private String readFile(Repository repository, RevCommit commit, String filepath) throws IOException {
+        TreeWalk walk = TreeWalk.forPath(repository, filepath, commit.getTree());
+        if (walk == null) {
+            throw new IllegalArgumentException(String.format("Filepath (%s) not found.", filepath));
+        }
+
+        byte[] bytes = repository.open(walk.getObjectId(0)).getBytes();
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+}

--- a/src/main/java/io/playrconf/provider/GitProvider.java
+++ b/src/main/java/io/playrconf/provider/GitProvider.java
@@ -175,7 +175,7 @@ public class GitProvider extends AbstractProvider {
      * Check if all required fields are set in the project config file.
      * @param config Config file.
      */
-    private void checkRequiredConfigFields(Config config) throws ConfigException {
+    private void checkRequiredConfigFields(final Config config) throws ConfigException {
         if (!config.hasPath("mode") || config.getString("mode").isEmpty())
             throw new ConfigException.Missing("mode");
 
@@ -232,10 +232,10 @@ public class GitProvider extends AbstractProvider {
                 final SshSessionFactory sshSessionFactory = new JschConfigSessionFactory() {
 
                     @Override
-                    protected JSch createDefaultJSch(FS fs) throws JSchException {
+                    protected JSch createDefaultJSch(final FS fs) throws JSchException {
                         // SSH configuration (Optional password).
-                        String privateKey = config.getString("ssh-rsa.private-key");
-                        String password = config.hasPath("ssh-rsa.password")
+                        final String privateKey = config.getString("ssh-rsa.private-key");
+                        final String password = config.hasPath("ssh-rsa.password")
                             ? config.getString("ssh-rsa.password") : null;
                         JSch jSch = super.createDefaultJSch(fs);
                         jSch.addIdentity(privateKey, password);
@@ -244,7 +244,7 @@ public class GitProvider extends AbstractProvider {
 
                 };
                 cloneCommand.setTransportConfigCallback(transport -> {
-                    SshTransport sshTransport = (SshTransport) transport;
+                    final SshTransport sshTransport = (SshTransport) transport;
                     sshTransport.setSshSessionFactory(sshSessionFactory);
                 });
                 break;
@@ -253,6 +253,7 @@ public class GitProvider extends AbstractProvider {
                 final String username = config.getString("user.login");
                 final String password = config.getString("user.password");
                 cloneCommand.setCredentialsProvider(new UsernamePasswordCredentialsProvider(username, password));
+                break;
 
             default:
                 // Public repository over HTTPS.

--- a/src/main/java/io/playrconf/provider/GitProvider.java
+++ b/src/main/java/io/playrconf/provider/GitProvider.java
@@ -112,22 +112,22 @@ public class GitProvider extends AbstractProvider {
     }
 
     @Override
-    public void loadData(Config config,
-                         Consumer<KeyValueCfgObject> kvObjConsumer,
-                         Consumer<FileCfgObject> fileObjConsumer) throws ConfigException, RemoteConfException {
+    public void loadData(final Config config,
+                         final Consumer<KeyValueCfgObject> kvObjConsumer,
+                         final Consumer<FileCfgObject> fileObjConsumer) throws ConfigException, RemoteConfException {
         this.checkRequiredConfigFields(config);
 
         try {
-            String mode = config.getString("mode").trim();
-            String repositoryURI = config.getString("uri").trim();
-            String branch = config.getString("branch").trim();
-            String filepath = config.getString("filepath").trim();
+            final String mode = config.getString("mode").trim();
+            final String repositoryURI = config.getString("uri").trim();
+            final String branch = config.getString("branch").trim();
+            final String filepath = config.getString("filepath").trim();
 
-            Repository repository = this.cloneRepository(config, repositoryURI, mode, branch);
-            ObjectId head = repository.resolve(Constants.HEAD);
-            RevCommit lastCommit = repository.parseCommit(head);
+            final Repository repository = this.cloneRepository(config, repositoryURI, mode, branch);
+            final ObjectId head = repository.resolve(Constants.HEAD);
+            final RevCommit lastCommit = repository.parseCommit(head);
 
-            String conf = readFile(repository, lastCommit, filepath);
+            final String conf = readFile(repository, lastCommit, filepath);
             final ConfigParseOptions options = ConfigParseOptions
                 .defaults()
                 .setOriginDescription("play-rconf")
@@ -188,8 +188,8 @@ public class GitProvider extends AbstractProvider {
         if (!config.hasPath("filepath") || config.getString("filepath").isEmpty())
             throw new ConfigException.Missing("filepath");
 
-        String mode = config.getString("mode").trim();
-        String repositoryURI = config.getString("uri").trim();
+        final String mode = config.getString("mode").trim();
+        final String repositoryURI = config.getString("uri").trim();
 
         if (Objects.equals(mode, "user")) {
             if (!repositoryURI.startsWith("http")) {
@@ -221,22 +221,22 @@ public class GitProvider extends AbstractProvider {
      * @param branch Branch name.
      * @return Repository.
      */
-    private Repository cloneRepository(Config config, String repositoryURI, String mode, String branch) throws GitAPIException {
-        File repoDir = new File("play-rconf-git", String.format("%s-%s-%d", repositoryURI, branch, System.currentTimeMillis()));
-        CloneCommand cloneCommand = Git.cloneRepository()
+    private Repository cloneRepository(final Config config, final String repositoryURI, final String mode, final String branch) throws GitAPIException {
+        final File repoDir = new File("play-rconf-git", String.format("%s-%s-%d", repositoryURI, branch, System.currentTimeMillis()));
+        final CloneCommand cloneCommand = Git.cloneRepository()
             .setURI(repositoryURI)
             .setDirectory(repoDir);
 
         switch (mode) {
             case "ssh-rsa":
-                SshSessionFactory sshSessionFactory = new JschConfigSessionFactory() {
+                final SshSessionFactory sshSessionFactory = new JschConfigSessionFactory() {
 
                     @Override
                     protected JSch createDefaultJSch(FS fs) throws JSchException {
                         // SSH configuration (Optional password).
                         String privateKey = config.getString("ssh-rsa.private-key");
-                        String password = config.hasPath("ssh-rsa.password") ?
-                            config.getString("ssh-rsa.password") : null;
+                        String password = config.hasPath("ssh-rsa.password")
+                            ? config.getString("ssh-rsa.password") : null;
                         JSch jSch = super.createDefaultJSch(fs);
                         jSch.addIdentity(privateKey, password);
                         return jSch;
@@ -250,8 +250,8 @@ public class GitProvider extends AbstractProvider {
                 break;
 
             case "user":
-                String username = config.getString("user.login");
-                String password = config.getString("user.password");
+                final String username = config.getString("user.login");
+                final String password = config.getString("user.password");
                 cloneCommand.setCredentialsProvider(new UsernamePasswordCredentialsProvider(username, password));
 
             default:
@@ -269,13 +269,13 @@ public class GitProvider extends AbstractProvider {
      * @param filepath Path to retrieve the config content.
      * @return Config content as String.
      */
-    private String readFile(Repository repository, RevCommit commit, String filepath) throws IOException {
-        TreeWalk walk = TreeWalk.forPath(repository, filepath, commit.getTree());
+    private String readFile(final Repository repository, final RevCommit commit, final String filepath) throws IOException {
+        final TreeWalk walk = TreeWalk.forPath(repository, filepath, commit.getTree());
         if (walk == null) {
             throw new IllegalArgumentException(String.format("Filepath (%s) not found.", filepath));
         }
 
-        byte[] bytes = repository.open(walk.getObjectId(0)).getBytes();
+        final byte[] bytes = repository.open(walk.getObjectId(0)).getBytes();
         return new String(bytes, StandardCharsets.UTF_8);
     }
 

--- a/src/main/java/io/playrconf/provider/GitProvider.java
+++ b/src/main/java/io/playrconf/provider/GitProvider.java
@@ -121,10 +121,9 @@ public class GitProvider extends AbstractProvider {
         try {
             final String mode = config.getString("mode").trim();
             final String repositoryURI = config.getString("uri").trim();
-            final String branch = config.getString("branch").trim();
             final String filepath = config.getString("filepath").trim();
 
-            final Repository repository = this.cloneRepository(config, repositoryURI, mode, branch);
+            final Repository repository = this.cloneRepository(config, repositoryURI, mode);
             final ObjectId head = repository.resolve(Constants.HEAD);
             final RevCommit lastCommit = repository.parseCommit(head);
 
@@ -183,9 +182,6 @@ public class GitProvider extends AbstractProvider {
         if (!config.hasPath("uri") || config.getString("uri").isEmpty())
             throw new ConfigException.Missing("uri");
 
-        if (!config.hasPath("branch") || config.getString("branch").isEmpty())
-            throw new ConfigException.Missing("branch");
-
         if (!config.hasPath("filepath") || config.getString("filepath").isEmpty())
             throw new ConfigException.Missing("filepath");
 
@@ -199,7 +195,7 @@ public class GitProvider extends AbstractProvider {
 
             if (!config.hasPath("user.login") || config.getString("user.login").isEmpty()) {
                 throw new ConfigException.Missing("user.login");
-            } else if (!config.hasPath("user.password")) {
+            } else if (!config.hasPath("user.password") || config.getString("user.password").isEmpty()) {
                 throw new ConfigException.Missing("user.password");
             }
         } else if (Objects.equals(mode, "ssh-rsa")) {
@@ -214,16 +210,15 @@ public class GitProvider extends AbstractProvider {
     }
 
     /**
-     * Clones the branch of Git repository.
+     * Clones main branch of Git repository.
      *
      * @param config Config file.
      * @param repositoryURI Repository URI using HTTPS or SSH.
      * @param mode Auth mode.
-     * @param branch Branch name.
      * @return Repository.
      */
-    private Repository cloneRepository(final Config config, final String repositoryURI, final String mode, final String branch) throws GitAPIException, IOException {
-        final String dirPath = String.format("play-rconf-git-%s", String.format("%s-%s-%d", repositoryURI, branch, System.currentTimeMillis()));
+    private Repository cloneRepository(final Config config, final String repositoryURI, final String mode) throws GitAPIException, IOException {
+        final String dirPath = String.format("play-rconf-git-%s", System.currentTimeMillis());
         final Path repoDirPath = Files.createTempDirectory(dirPath);
         final CloneCommand cloneCommand = Git.cloneRepository()
             .setURI(repositoryURI)
@@ -268,7 +263,7 @@ public class GitProvider extends AbstractProvider {
     /**
      * Read config file from repository.
      * @param repository Repository ref.
-     * @param commit Last commit ref from the current branch.
+     * @param commit Last commit ref from the main branch.
      * @param filepath Path to retrieve the config content.
      * @return Config content as String.
      */

--- a/src/main/java/io/playrconf/provider/GitProvider.java
+++ b/src/main/java/io/playrconf/provider/GitProvider.java
@@ -193,7 +193,7 @@ public class GitProvider extends AbstractProvider {
 
         if (Objects.equals(mode, "user")) {
             if (!repositoryURI.startsWith("http")) {
-                throw new ConfigException.BadValue("mode", String.format("Invalid repository URI for %s mode.", mode));
+                throw new ConfigException.BadPath("mode", String.format("Invalid repository URI for %s mode.", mode));
             }
 
             if (!config.hasPath("user.login") || config.getString("user.login").isEmpty()) {
@@ -203,7 +203,7 @@ public class GitProvider extends AbstractProvider {
             }
         } else if (Objects.equals(mode, "ssh-rsa")) {
             if (!repositoryURI.startsWith("git@")) {
-                throw new ConfigException.BadValue("mode", String.format("Invalid repository URI for %s mode.", mode));
+                throw new ConfigException.BadPath("mode", String.format("Invalid repository URI for %s mode.", mode));
             }
 
             if (!config.hasPath("ssh-rsa.private-key") || config.getString("ssh-rsa.private-key").isEmpty()) {

--- a/src/main/java/io/playrconf/provider/GitProvider.java
+++ b/src/main/java/io/playrconf/provider/GitProvider.java
@@ -223,8 +223,8 @@ public class GitProvider extends AbstractProvider {
      * @return Repository.
      */
     private Repository cloneRepository(final Config config, final String repositoryURI, final String mode, final String branch) throws GitAPIException, IOException {
-        String dirPath = String.format("play-rconf-git-%s", String.format("%s-%s-%d", repositoryURI, branch, System.currentTimeMillis()));
-        Path repoDirPath = Files.createTempDirectory(dirPath);
+        final String dirPath = String.format("play-rconf-git-%s", String.format("%s-%s-%d", repositoryURI, branch, System.currentTimeMillis()));
+        final Path repoDirPath = Files.createTempDirectory(dirPath);
         final CloneCommand cloneCommand = Git.cloneRepository()
             .setURI(repositoryURI)
             .setDirectory(repoDirPath.toFile());

--- a/src/main/java/io/playrconf/provider/GitProvider.java
+++ b/src/main/java/io/playrconf/provider/GitProvider.java
@@ -237,7 +237,7 @@ public class GitProvider extends AbstractProvider {
                         final String privateKey = config.getString("ssh-rsa.private-key");
                         final String password = config.hasPath("ssh-rsa.password")
                             ? config.getString("ssh-rsa.password") : null;
-                        JSch jSch = super.createDefaultJSch(fs);
+                        final JSch jSch = super.createDefaultJSch(fs);
                         jSch.addIdentity(privateKey, password);
                         return jSch;
                     }

--- a/src/main/resources/playrconf-git.properties
+++ b/src/main/resources/playrconf-git.properties
@@ -1,0 +1,1 @@
+playrconf.git.version=${version}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -8,11 +8,6 @@ remote-configuration {
     uri = ""
     uri = ${?REMOTECONF_GIT_URI}
 
-    # Branch name to be fetch.
-    # e.g. master, development, etc.
-    branch = ""
-    branch = ${?REMOTECONF_GIT_BRANCH}
-
     # File path to get the raw conf content.
     # e.g. /src/app/conf/application.conf
     filepath = ""

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,37 @@
+remote-configuration {
+
+  ## Provider - Git
+  # ~~~~~
+  # Retrieves configuration from a simple Git repository
+  http {
+
+    uri = ""
+    uri = ${?REMOTECONF_GIT_URI}
+
+    # Branch name to be fetch.
+    # e.g. master, development, etc.
+    branch = ""
+    branch = ${?REMOTECONF_GIT_BRANCH}
+
+    # File path to get the raw conf content.
+    # e.g. /src/app/conf/application.conf
+    filepath = ""
+    filepath = ${?REMOTECONF_GIT_FILEPATH}
+
+    # Git authentication mode
+    # You can use:
+    #   1. none or empty => Public repository.
+    #   2. user => Basic auth with login and password.
+    #   3. ssh-rsa => SSH using a RSA private key.
+    mode = ""
+    mode = ${?REMOTECONF_GIT_MODE}
+
+    # If you set 'user' mode, then you must provide login and password.
+    #user.login = ""
+    #user.password = ""
+
+    # If you set 'ssh-rsa' mode, then you must provide a private key and an optional password.
+    #ssh-rsa.password = ""
+    #ssh-rsa.private-key = ""
+  }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -3,7 +3,7 @@ remote-configuration {
   ## Provider - Git
   # ~~~~~
   # Retrieves configuration from a simple Git repository
-  http {
+  git {
 
     uri = ""
     uri = ${?REMOTECONF_GIT_URI}

--- a/src/test/java/io/playrconf/provider/GitProviderTest.java
+++ b/src/test/java/io/playrconf/provider/GitProviderTest.java
@@ -361,17 +361,17 @@ public class GitProviderTest {
         loadConfigWithError(INITIAL_CONFIGURATION_ERROR_MISSING_PRIVATE_KEY_FOR_SSH_MODE);
     }
 
-    @Test(expected = ConfigException.BadValue.class)
+    @Test(expected = ConfigException.BadPath.class)
     public void gitTest_012() {
         loadConfigWithError(INITIAL_CONFIGURATION_ERROR_URI_BAD_VALUE_FOR_NONE_MODE);
     }
 
-    @Test(expected = ConfigException.BadValue.class)
+    @Test(expected = ConfigException.BadPath.class)
     public void gitTest_013() {
         loadConfigWithError(INITIAL_CONFIGURATION_ERROR_URI_BAD_VALUE_FOR_USER_MODE);
     }
 
-    @Test(expected = ConfigException.BadValue.class)
+    @Test(expected = ConfigException.BadPath.class)
     public void gitTest_014() {
         loadConfigWithError(INITIAL_CONFIGURATION_ERROR_URI_BAD_VALUE_FOR_SSH_RSA_MODE);
     }

--- a/src/test/java/io/playrconf/provider/GitProviderTest.java
+++ b/src/test/java/io/playrconf/provider/GitProviderTest.java
@@ -64,7 +64,6 @@ public class GitProviderTest {
     private static final Config INITIAL_CONFIGURATION_FOR_NONE_MODE = ConfigFactory.parseString(
         "application.hello = \"Bad value\"\n"
             + "git.uri = \"" + System.getenv("REMOTECONF_GIT_URI") + "\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
             + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
             + "git.mode = \"none\"\n"
     );
@@ -75,7 +74,6 @@ public class GitProviderTest {
     private static final Config INITIAL_CONFIGURATION_FOR_USER_MODE = ConfigFactory.parseString(
         "application.hello = \"Bad value\"\n"
             + "git.uri = \"" + System.getenv("REMOTECONF_GIT_USER_URI") + "\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
             + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
             + "git.mode = \"user\"\n"
             + "git.user.login = \"" + System.getenv("REMOTECONF_GIT_USER_LOGIN") + "\"\n"
@@ -88,18 +86,6 @@ public class GitProviderTest {
     private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_URI = ConfigFactory.parseString(
         "application.hello = \"Bad value\"\n"
             + "git.uri = \"\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
-            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
-            + "git.mode = \"none\"\n"
-    );
-
-    /**
-     * Initial configuration. Git repository URI is empty.
-     */
-    private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_BRANCH = ConfigFactory.parseString(
-        "application.hello = \"Bad value\"\n"
-            + "git.uri = \"" + System.getenv("REMOTECONF_GIT_URI") + "\"\n"
-            + "git.branch = \"\"\n"
             + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
             + "git.mode = \"none\"\n"
     );
@@ -110,7 +96,6 @@ public class GitProviderTest {
     private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_FILEPATH = ConfigFactory.parseString(
         "application.hello = \"Bad value\"\n"
             + "git.uri = \"" + System.getenv("REMOTECONF_GIT_URI") + "\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
             + "git.filepath = \"\"\n"
             + "git.mode = \"none\"\n"
     );
@@ -121,7 +106,6 @@ public class GitProviderTest {
     private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_MODE = ConfigFactory.parseString(
         "application.hello = \"Bad value\"\n"
             + "git.uri = \"" + System.getenv("REMOTECONF_GIT_URI") + "\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
             + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
             + "git.mode = \"\"\n"
     );
@@ -132,7 +116,6 @@ public class GitProviderTest {
     private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_LOGIN_FOR_USER_MODE = ConfigFactory.parseString(
         "application.hello = \"Bad value\"\n"
             + "git.uri = \"" + System.getenv("REMOTECONF_GIT_USER_URI") + "\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
             + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
             + "git.mode = \"user\"\n"
             + "git.user.login = \"\"\n"
@@ -145,7 +128,6 @@ public class GitProviderTest {
     private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_PASSWORD_FOR_USER_MODE = ConfigFactory.parseString(
         "application.hello = \"Bad value\"\n"
             + "git.uri = \"" + System.getenv("REMOTECONF_GIT_USER_URI") + "\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
             + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
             + "git.mode = \"user\"\n"
             + "git.user.login = \"" + System.getenv("REMOTECONF_GIT_USER_LOGIN") + "\"\n"
@@ -158,7 +140,6 @@ public class GitProviderTest {
     private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_PRIVATE_KEY_FOR_SSH_MODE = ConfigFactory.parseString(
         "application.hello = \"Bad value\"\n"
             + "git.uri = \"" + System.getenv("REMOTECONF_GIT_SSH_URI") + "\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
             + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
             + "git.mode = \"ssh-rsa\"\n"
             + "git.ssh-rsa.private-key = \"\"\n"
@@ -170,7 +151,6 @@ public class GitProviderTest {
     private static final Config INITIAL_CONFIGURATION_ERROR_URI_BAD_VALUE_FOR_NONE_MODE = ConfigFactory.parseString(
         "application.hello = \"Bad value\"\n"
             + "git.uri = \"git@github.com/play-rconf/play-rconf-git.git\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
             + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
             + "git.mode = \"none\"\n"
     );
@@ -181,7 +161,6 @@ public class GitProviderTest {
     private static final Config INITIAL_CONFIGURATION_ERROR_URI_BAD_VALUE_FOR_USER_MODE = ConfigFactory.parseString(
         "application.hello = \"Bad value\"\n"
             + "git.uri = \"git@github.com/play-rconf/play-rconf-git.git\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
             + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
             + "git.mode = \"user\"\n"
     );
@@ -192,7 +171,6 @@ public class GitProviderTest {
     private static final Config INITIAL_CONFIGURATION_ERROR_URI_BAD_VALUE_FOR_SSH_RSA_MODE = ConfigFactory.parseString(
         "application.hello = \"Bad value\"\n"
             + "git.uri = \"https://github.com/play-rconf/play-rconf-git\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
             + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
             + "git.mode = \"ssh-rsa\"\n"
     );
@@ -203,7 +181,6 @@ public class GitProviderTest {
     private static final Config INITIAL_CONFIGURATION_ERROR_UNKNOWN_GIT_URI = ConfigFactory.parseString(
         "application.hello = \"Bad value\"\n"
             + "git.uri = \"https://doma1n-do3s-not-3x15t5-2832893729387.com\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
             + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
             + "git.mode = \"none\"\n"
     );
@@ -262,11 +239,6 @@ public class GitProviderTest {
     @Test(expected = ConfigException.Missing.class)
     public void gitTest_005() {
         loadConfigWithError(INITIAL_CONFIGURATION_ERROR_MISSING_URI);
-    }
-
-    @Test(expected = ConfigException.Missing.class)
-    public void gitTest_006() {
-        loadConfigWithError(INITIAL_CONFIGURATION_ERROR_MISSING_BRANCH);
     }
 
     @Test(expected = ConfigException.Missing.class)

--- a/src/test/java/io/playrconf/provider/GitProviderTest.java
+++ b/src/test/java/io/playrconf/provider/GitProviderTest.java
@@ -51,10 +51,6 @@ import java.util.Properties;
  *          a) REMOTECONF_GIT_USER_URI
  *          b) REMOTECONF_GIT_USER_LOGIN
  *          c) REMOTECONF_GIT_USER_PASSWORD
- *      2. For ssh-rsa mode:
- *          a) REMOTECONF_GIT_SSH_URI
- *          b) REMOTECONF_GIT_SSH_PRIVATE_KEY_PATH
- *          c) REMOTECONF_GIT_SSH_PASSWORD
  *
  * @author Felipe Boenzi
  * @since 20.10.29
@@ -84,31 +80,6 @@ public class GitProviderTest {
             + "git.mode = \"user\"\n"
             + "git.user.login = \"" + System.getenv("REMOTECONF_GIT_USER_LOGIN") + "\"\n"
             + "git.user.password = \"" + System.getenv("REMOTECONF_GIT_USER_PASSWORD") + "\"\n"
-    );
-
-    /**
-     * Initial configuration for private repository with SSH-RSA authentication without password.
-     */
-    private static final Config INITIAL_CONFIGURATION_FOR_SSH_MODE = ConfigFactory.parseString(
-        "application.hello = \"Bad value\"\n"
-            + "git.uri = \"" + System.getenv("REMOTECONF_GIT_SSH_URI") + "\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
-            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
-            + "git.mode = \"ssh-rsa\"\n"
-            + "git.ssh-rsa.private-key = \"" + System.getenv("REMOTECONF_GIT_SSH_RSA_PRIVATE_KEY_PATH") + "\"\n"
-            + "git.ssh-rsa.password = \"" + System.getenv("REMOTECONF_GIT_SSH_RSA_PASSWORD") + "\"\n"
-    );
-
-    /**
-     * Initial configuration for private repository with SSH-RSA authentication.
-     */
-    private static final Config INITIAL_CONFIGURATION_FOR_SSH_MODE_WITHOUT_PASSWORD = ConfigFactory.parseString(
-        "application.hello = \"Bad value\"\n"
-            + "git.uri = \"" + System.getenv("REMOTECONF_GIT_SSH_URI") + "\"\n"
-            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
-            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
-            + "git.mode = \"ssh-rsa\"\n"
-            + "git.ssh-rsa.private-key = \"" + System.getenv("REMOTECONF_GIT_SSH_PRIVATE_KEY_PATH") + "\"\n"
     );
 
     /**
@@ -281,44 +252,6 @@ public class GitProviderTest {
         final Config remoteConfig = ConfigFactory
             .parseString(stringBuilder.toString())
             .withFallback(INITIAL_CONFIGURATION_FOR_USER_MODE);
-
-        // Standard values
-        Assert.assertEquals(5, remoteConfig.getInt("application.five"));
-        Assert.assertEquals("world", remoteConfig.getString("application.hello"));
-        Assert.assertTrue(remoteConfig.getBoolean("application.is-enabled"));
-    }
-
-    @Test
-    public void gitTest_003() {
-        final StringBuilder stringBuilder = new StringBuilder(512);
-        final Provider provider = new GitProvider();
-        provider.loadData(
-            INITIAL_CONFIGURATION_FOR_SSH_MODE.getConfig(provider.getConfigurationObjectName()),
-            keyValueCfgObject -> keyValueCfgObject.apply(stringBuilder),
-            FileCfgObject::apply
-        );
-        final Config remoteConfig = ConfigFactory
-            .parseString(stringBuilder.toString())
-            .withFallback(INITIAL_CONFIGURATION_FOR_SSH_MODE);
-
-        // Standard values
-        Assert.assertEquals(5, remoteConfig.getInt("application.five"));
-        Assert.assertEquals("world", remoteConfig.getString("application.hello"));
-        Assert.assertTrue(remoteConfig.getBoolean("application.is-enabled"));
-    }
-
-    @Test
-    public void gitTest_004() {
-        final StringBuilder stringBuilder = new StringBuilder(512);
-        final Provider provider = new GitProvider();
-        provider.loadData(
-            INITIAL_CONFIGURATION_FOR_SSH_MODE_WITHOUT_PASSWORD.getConfig(provider.getConfigurationObjectName()),
-            keyValueCfgObject -> keyValueCfgObject.apply(stringBuilder),
-            FileCfgObject::apply
-        );
-        final Config remoteConfig = ConfigFactory
-            .parseString(stringBuilder.toString())
-            .withFallback(INITIAL_CONFIGURATION_FOR_SSH_MODE_WITHOUT_PASSWORD);
 
         // Standard values
         Assert.assertEquals(5, remoteConfig.getInt("application.five"));

--- a/src/test/java/io/playrconf/provider/GitProviderTest.java
+++ b/src/test/java/io/playrconf/provider/GitProviderTest.java
@@ -1,0 +1,397 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 The Play Remote Configuration Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.playrconf.provider;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+import io.playrconf.sdk.FileCfgObject;
+import io.playrconf.sdk.Provider;
+import org.junit.Assert;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * GitProviderTest.
+ *
+ * Default environment variables:
+ *      1. REMOTECONF_GIT_BRANCH
+ *      2. REMOTECONF_GIT_FILEPATH
+ *
+ * Required environment variables:
+ *      1. For none mode:
+ *          a) REMOTECONF_GIT_URI
+ *      2. For user mode:
+ *          a) REMOTECONF_GIT_USER_URI
+ *          b) REMOTECONF_GIT_USER_LOGIN
+ *          c) REMOTECONF_GIT_USER_PASSWORD
+ *      2. For ssh-rsa mode:
+ *          a) REMOTECONF_GIT_SSH_URI
+ *          b) REMOTECONF_GIT_SSH_PRIVATE_KEY_PATH
+ *          c) REMOTECONF_GIT_SSH_PASSWORD
+ *
+ * @author Felipe Boenzi
+ * @since 20.10.29
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class GitProviderTest {
+
+    /**
+     * Initial configuration for public repository.
+     */
+    private static final Config INITIAL_CONFIGURATION_FOR_NONE_MODE = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"" + System.getenv("REMOTECONF_GIT_URI") + "\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"none\"\n"
+    );
+
+    /**
+     * Initial configuration for private repository with login and password authentication.
+     */
+    private static final Config INITIAL_CONFIGURATION_FOR_USER_MODE = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"" + System.getenv("REMOTECONF_GIT_USER_URI") + "\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"user\"\n"
+            + "git.user.login = \"" + System.getenv("REMOTECONF_GIT_USER_LOGIN") + "\"\n"
+            + "git.user.password = \"" + System.getenv("REMOTECONF_GIT_USER_PASSWORD") + "\"\n"
+    );
+
+    /**
+     * Initial configuration for private repository with SSH-RSA authentication without password.
+     */
+    private static final Config INITIAL_CONFIGURATION_FOR_SSH_MODE = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"" + System.getenv("REMOTECONF_GIT_SSH_URI") + "\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"ssh-rsa\"\n"
+            + "git.ssh-rsa.private-key = \"" + System.getenv("REMOTECONF_GIT_SSH_RSA_PRIVATE_KEY_PATH") + "\"\n"
+            + "git.ssh-rsa.password = \"" + System.getenv("REMOTECONF_GIT_SSH_RSA_PASSWORD") + "\"\n"
+    );
+
+    /**
+     * Initial configuration for private repository with SSH-RSA authentication.
+     */
+    private static final Config INITIAL_CONFIGURATION_FOR_SSH_MODE_WITHOUT_PASSWORD = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"" + System.getenv("REMOTECONF_GIT_SSH_URI") + "\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"ssh-rsa\"\n"
+            + "git.ssh-rsa.private-key = \"" + System.getenv("REMOTECONF_GIT_SSH_PRIVATE_KEY_PATH") + "\"\n"
+    );
+
+    /**
+     * Initial configuration. Git repository URI is empty.
+     */
+    private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_URI = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"none\"\n"
+    );
+
+    /**
+     * Initial configuration. Git repository URI is empty.
+     */
+    private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_BRANCH = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"" + System.getenv("REMOTECONF_GIT_URI") + "\"\n"
+            + "git.branch = \"\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"none\"\n"
+    );
+
+    /**
+     * Initial configuration. Git repository URI is empty.
+     */
+    private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_FILEPATH = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"" + System.getenv("REMOTECONF_GIT_URI") + "\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"\"\n"
+            + "git.mode = \"none\"\n"
+    );
+
+    /**
+     * Initial configuration. Git repository URI is empty.
+     */
+    private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_MODE = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"" + System.getenv("REMOTECONF_GIT_URI") + "\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"\"\n"
+    );
+
+    /**
+     * Initial configuration. Git repository URI is empty.
+     */
+    private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_LOGIN_FOR_USER_MODE = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"" + System.getenv("REMOTECONF_GIT_USER_URI") + "\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"user\"\n"
+            + "git.user.login = \"\"\n"
+            + "git.user.password = \"" + System.getenv("REMOTECONF_GIT_USER_PASSWORD") + "\"\n"
+    );
+
+    /**
+     * Initial configuration. Git repository URI is empty.
+     */
+    private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_PASSWORD_FOR_USER_MODE = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"" + System.getenv("REMOTECONF_GIT_USER_URI") + "\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"user\"\n"
+            + "git.user.login = \"" + System.getenv("REMOTECONF_GIT_USER_LOGIN") + "\"\n"
+            + "git.user.password = \"\"\n"
+    );
+
+    /**
+     * Initial configuration. Git repository URI is empty.
+     */
+    private static final Config INITIAL_CONFIGURATION_ERROR_MISSING_PRIVATE_KEY_FOR_SSH_MODE = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"" + System.getenv("REMOTECONF_GIT_SSH_URI") + "\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"ssh-rsa\"\n"
+            + "git.ssh-rsa.private-key = \"\"\n"
+    );
+
+    /**
+     * Initial configuration. Git repository URI is empty.
+     */
+    private static final Config INITIAL_CONFIGURATION_ERROR_URI_BAD_VALUE_FOR_NONE_MODE = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"git@github.com/play-rconf/play-rconf-git.git\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"none\"\n"
+    );
+
+    /**
+     * Initial configuration. Git repository URI is empty.
+     */
+    private static final Config INITIAL_CONFIGURATION_ERROR_URI_BAD_VALUE_FOR_USER_MODE = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"git@github.com/play-rconf/play-rconf-git.git\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"user\"\n"
+    );
+
+    /**
+     * Initial configuration. Git repository URI is empty.
+     */
+    private static final Config INITIAL_CONFIGURATION_ERROR_URI_BAD_VALUE_FOR_SSH_RSA_MODE = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"https://github.com/play-rconf/play-rconf-git\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"ssh-rsa\"\n"
+    );
+
+    /**
+     * Initial configuration. Git repository URI is empty.
+     */
+    private static final Config INITIAL_CONFIGURATION_ERROR_UNKNOWN_GIT_URI = ConfigFactory.parseString(
+        "application.hello = \"Bad value\"\n"
+            + "git.uri = \"https://doma1n-do3s-not-3x15t5-2832893729387.com\"\n"
+            + "git.branch = \"" + System.getenv("REMOTECONF_GIT_BRANCH") + "\"\n"
+            + "git.filepath = \"" + System.getenv("REMOTECONF_GIT_FILEPATH") + "\"\n"
+            + "git.mode = \"none\"\n"
+    );
+
+    @Test
+    public void gitTest_001() {
+        final StringBuilder stringBuilder = new StringBuilder(512);
+        final Provider provider = new GitProvider();
+        provider.loadData(
+            INITIAL_CONFIGURATION_FOR_NONE_MODE.getConfig(provider.getConfigurationObjectName()),
+            keyValueCfgObject -> keyValueCfgObject.apply(stringBuilder),
+            FileCfgObject::apply
+        );
+        final Config remoteConfig = ConfigFactory
+            .parseString(stringBuilder.toString())
+            .withFallback(INITIAL_CONFIGURATION_FOR_NONE_MODE);
+
+        // Test version
+        final Properties properties = new Properties();
+        try (InputStream is = GitProvider.class.getClassLoader()
+            .getResourceAsStream("playrconf-git.properties")) {
+            properties.load(is);
+            Assert.assertEquals(
+                provider.getVersion(),
+                properties.getProperty("playrconf.git.version", "unknown")
+            );
+            properties.clear();
+        } catch (final IOException ignore) {
+        }
+
+        // Standard values
+        Assert.assertEquals(5, remoteConfig.getInt("application.five"));
+        Assert.assertEquals("world", remoteConfig.getString("application.hello"));
+        Assert.assertTrue(remoteConfig.getBoolean("application.is-enabled"));
+    }
+
+    @Test
+    public void gitTest_002() {
+        final StringBuilder stringBuilder = new StringBuilder(512);
+        final Provider provider = new GitProvider();
+        provider.loadData(
+            INITIAL_CONFIGURATION_FOR_USER_MODE.getConfig(provider.getConfigurationObjectName()),
+            keyValueCfgObject -> keyValueCfgObject.apply(stringBuilder),
+            FileCfgObject::apply
+        );
+        final Config remoteConfig = ConfigFactory
+            .parseString(stringBuilder.toString())
+            .withFallback(INITIAL_CONFIGURATION_FOR_USER_MODE);
+
+        // Standard values
+        Assert.assertEquals(5, remoteConfig.getInt("application.five"));
+        Assert.assertEquals("world", remoteConfig.getString("application.hello"));
+        Assert.assertTrue(remoteConfig.getBoolean("application.is-enabled"));
+    }
+
+    @Test
+    public void gitTest_003() {
+        final StringBuilder stringBuilder = new StringBuilder(512);
+        final Provider provider = new GitProvider();
+        provider.loadData(
+            INITIAL_CONFIGURATION_FOR_SSH_MODE.getConfig(provider.getConfigurationObjectName()),
+            keyValueCfgObject -> keyValueCfgObject.apply(stringBuilder),
+            FileCfgObject::apply
+        );
+        final Config remoteConfig = ConfigFactory
+            .parseString(stringBuilder.toString())
+            .withFallback(INITIAL_CONFIGURATION_FOR_SSH_MODE);
+
+        // Standard values
+        Assert.assertEquals(5, remoteConfig.getInt("application.five"));
+        Assert.assertEquals("world", remoteConfig.getString("application.hello"));
+        Assert.assertTrue(remoteConfig.getBoolean("application.is-enabled"));
+    }
+
+    @Test
+    public void gitTest_004() {
+        final StringBuilder stringBuilder = new StringBuilder(512);
+        final Provider provider = new GitProvider();
+        provider.loadData(
+            INITIAL_CONFIGURATION_FOR_SSH_MODE_WITHOUT_PASSWORD.getConfig(provider.getConfigurationObjectName()),
+            keyValueCfgObject -> keyValueCfgObject.apply(stringBuilder),
+            FileCfgObject::apply
+        );
+        final Config remoteConfig = ConfigFactory
+            .parseString(stringBuilder.toString())
+            .withFallback(INITIAL_CONFIGURATION_FOR_SSH_MODE_WITHOUT_PASSWORD);
+
+        // Standard values
+        Assert.assertEquals(5, remoteConfig.getInt("application.five"));
+        Assert.assertEquals("world", remoteConfig.getString("application.hello"));
+        Assert.assertTrue(remoteConfig.getBoolean("application.is-enabled"));
+    }
+
+    @Test(expected = ConfigException.Missing.class)
+    public void gitTest_005() {
+        loadConfigWithError(INITIAL_CONFIGURATION_ERROR_MISSING_URI);
+    }
+
+    @Test(expected = ConfigException.Missing.class)
+    public void gitTest_006() {
+        loadConfigWithError(INITIAL_CONFIGURATION_ERROR_MISSING_BRANCH);
+    }
+
+    @Test(expected = ConfigException.Missing.class)
+    public void gitTest_007() {
+        loadConfigWithError(INITIAL_CONFIGURATION_ERROR_MISSING_FILEPATH);
+    }
+
+    @Test(expected = ConfigException.Missing.class)
+    public void gitTest_008() {
+        loadConfigWithError(INITIAL_CONFIGURATION_ERROR_MISSING_MODE);
+    }
+
+    @Test(expected = ConfigException.Missing.class)
+    public void gitTest_009() {
+        loadConfigWithError(INITIAL_CONFIGURATION_ERROR_MISSING_LOGIN_FOR_USER_MODE);
+    }
+
+    @Test(expected = ConfigException.Missing.class)
+    public void gitTest_010() {
+        loadConfigWithError(INITIAL_CONFIGURATION_ERROR_MISSING_PASSWORD_FOR_USER_MODE);
+    }
+
+    @Test(expected = ConfigException.Missing.class)
+    public void gitTest_011() {
+        loadConfigWithError(INITIAL_CONFIGURATION_ERROR_MISSING_PRIVATE_KEY_FOR_SSH_MODE);
+    }
+
+    @Test(expected = ConfigException.BadValue.class)
+    public void gitTest_012() {
+        loadConfigWithError(INITIAL_CONFIGURATION_ERROR_URI_BAD_VALUE_FOR_NONE_MODE);
+    }
+
+    @Test(expected = ConfigException.BadValue.class)
+    public void gitTest_013() {
+        loadConfigWithError(INITIAL_CONFIGURATION_ERROR_URI_BAD_VALUE_FOR_USER_MODE);
+    }
+
+    @Test(expected = ConfigException.BadValue.class)
+    public void gitTest_014() {
+        loadConfigWithError(INITIAL_CONFIGURATION_ERROR_URI_BAD_VALUE_FOR_SSH_RSA_MODE);
+    }
+
+    @Test(expected = ConfigException.BadPath.class)
+    public void gitTest_015() {
+        loadConfigWithError(INITIAL_CONFIGURATION_ERROR_UNKNOWN_GIT_URI);
+    }
+
+    private void loadConfigWithError(Config initialConfigurationErrorEmptyFilepath) throws ConfigException {
+        final StringBuilder stringBuilder = new StringBuilder(512);
+        final Provider provider = new GitProvider();
+        provider.loadData(
+            initialConfigurationErrorEmptyFilepath.getConfig(provider.getConfigurationObjectName()),
+            keyValueCfgObject -> keyValueCfgObject.apply(stringBuilder),
+            FileCfgObject::apply
+        );
+        ConfigFactory
+            .parseString(stringBuilder.toString())
+            .withFallback(initialConfigurationErrorEmptyFilepath);
+    }
+
+}

--- a/src/test/resources/playrconf-git.properties
+++ b/src/test/resources/playrconf-git.properties
@@ -1,0 +1,1 @@
+playrconf.git.version=${version}


### PR DESCRIPTION
# Version 1.0.0

- ✨ **Add GitProvider to retrieve conf file from Git Server.**
   - You can retrieve file using three auth modes:
        1. None or Empty (For public repositories);
        2. user (For private repositories over login and password);
        3. ssh-rsa (For private repositories over SSH RSA private key).

**Issue Ref:** [#1](https://github.com/play-rconf/play-rconf-sdk/issues/1)